### PR TITLE
Change the way the image/container bundles the code for deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM node:12 as sri-front
 
 WORKDIR /app
 
-ADD ./bundle-pj.sh /app/bundle-pj.sh
-RUN chmod +x bundle-pj.sh
-
 COPY . ./
 
 RUN mkdir -p /bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
 FROM node:12 as sri-front
 
 WORKDIR /app
-COPY . ./
 
-RUN mkdir -p /app/bundle
-VOLUME /app/bundle
-
-RUN yarn
-RUN yarn add babel-plugin-relay
+RUN mkdir -p /bundle
+VOLUME /bundle
 
 ADD ./bundle-pj.sh /app/bundle-pj.sh
 RUN chmod +x bundle-pj.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:12 as sri-front
 WORKDIR /app
 
 COPY . ./
+RUN chmod +x bundle-pj.sh
 
 RUN mkdir -p /bundle
 VOLUME /bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,12 @@ FROM node:12 as sri-front
 
 WORKDIR /app
 
+ADD ./bundle-pj.sh /app/bundle-pj.sh
+RUN chmod +x bundle-pj.sh
+
+COPY . ./
+
 RUN mkdir -p /bundle
 VOLUME /bundle
 
-ADD ./bundle-pj.sh /app/bundle-pj.sh
-RUN chmod +x bundle-pj.sh
 ENTRYPOINT ["/app/bundle-pj.sh"]

--- a/bundle-pj.sh
+++ b/bundle-pj.sh
@@ -3,8 +3,6 @@
 set -e
 set -x
 
-cp -r /source/* /app/
-
 yarn
 yarn add babel-plugin-relay
 yarn build

--- a/bundle-pj.sh
+++ b/bundle-pj.sh
@@ -3,6 +3,11 @@
 set -e
 set -x
 
+cp -r /source/* /app/
+
+yarn
+yarn add babel-plugin-relay
 yarn build
-rm -rf bundle/*
-cp -r build/* bundle/
+
+rm -rf /bundle/*
+cp -r build/* /bundle/


### PR DESCRIPTION
Another volume is added for the sri-front container, so the bundle is made from the code from this volume, instead of the code copied on docker image building.